### PR TITLE
feat: add txt_record_verified to zone

### DIFF
--- a/lib/dennis/zone.rb
+++ b/lib/dennis/zone.rb
@@ -106,6 +106,10 @@ module Dennis
       @hash['nameservers_verified']
     end
 
+    def txt_record_verified?
+      @hash['txt_record_verified']
+    end
+
     def verified?
       @hash['verified']
     end


### PR DESCRIPTION
Katapult issue: https://github.com/krystal/katapult/issues/4976

We need to exposed a new field `txt_record_verified` via the dennis API.