### PR TITLE
feat: support custom nameservers in group creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Metrics/ModuleLength:
 
 Metrics/AbcSize:
   Enabled: false
+
+Naming/PredicateMethod:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,4 @@ gem 'vcr'
 gem 'webmock'
 
 gem 'rake'
-gem 'rubocop', '~> 1.50'
+gem 'rubocop', '~> 1.65'

--- a/lib/dennis/group.rb
+++ b/lib/dennis/group.rb
@@ -2,6 +2,7 @@
 
 require 'dennis/nameserver'
 require 'dennis/validation_error'
+require 'dennis/nameserver_not_found_error'
 
 module Dennis
   class Group
@@ -25,11 +26,16 @@ module Dennis
         e.code == 'group_not_found' ? nil : raise
       end
 
-      def create(client, name:, external_reference: nil)
+      def create(client, name:, external_reference: nil, nameservers: nil)
         request = client.api.create_request(:post, 'groups')
-        request.arguments[:properties] = { name: name, external_reference: external_reference }
+        request.arguments[:properties] = {
+          name: name,
+          external_reference: external_reference,
+          nameservers: nameservers
+        }
         Group.new(client, request.perform.hash['group'])
       rescue ApiaClient::RequestError => e
+        raise NameserverNotFoundError, e.detail['errors'] if e.code == 'nameserver_not_found'
         raise ValidationError, e.detail['errors'] if e.code == 'validation_error'
 
         raise

--- a/lib/dennis/nameserver_not_found_error.rb
+++ b/lib/dennis/nameserver_not_found_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'dennis/error'
+
+module Dennis
+  class NameserverNotFoundError < Error
+  end
+end

--- a/spec/fixtures/vcr_cassettes/group-create-nameservers-name-validation-error.yml
+++ b/spec/fixtures/vcr_cassettes/group-create-nameservers-name-validation-error.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://dennis.localhost/api/v1/groups
+    body:
+      encoding: UTF-8
+      string: '{"properties":{"name":"Fig Group","external_reference":"figs","nameservers":[{"name":"unknown"}]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '141'
+      Content-Type:
+      - application/json
+      Server:
+      - Caddy
+      Server-Timing:
+      - sql.active_record;dur=1.54, instantiation.active_record;dur=0.05
+      X-Api-Schema:
+      - json-error
+      X-Request-Id:
+      - 2ef8380b-5be6-4b8c-98d1-5c60a1c4e657
+      X-Runtime:
+      - '0.006678'
+      Date:
+      - Thu, 11 Sep 2025 11:17:26 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"nameserver_not_found","description":"No nameserver
+        could be found using the given arguments","detail":{"query":"unknown"}}}'
+  recorded_at: Thu, 11 Sep 2025 11:17:26 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/group-create-nameservers-name.yml
+++ b/spec/fixtures/vcr_cassettes/group-create-nameservers-name.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://dennis.localhost/api/v1/groups
+    body:
+      encoding: UTF-8
+      string: '{"properties":{"name":"Peach Group","external_reference":"peaches","nameservers":[{"name":"dave.example.com"}]}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '245'
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"1dbd399503ff84e41b1ea2983dc4f546"
+      Server:
+      - Caddy
+      Server-Timing:
+      - sql.active_record;dur=5.97, instantiation.active_record;dur=0.04
+      X-Request-Id:
+      - 79150f53-1f46-4be0-83c6-0d8f20fe4c00
+      X-Runtime:
+      - '0.016797'
+      Date:
+      - Thu, 11 Sep 2025 11:17:26 GMT
+    body:
+      encoding: UTF-8
+      string: '{"group":{"id":7,"name":"Peach Group","external_reference":"peaches","created_at":1757589446,"updated_at":1757589446,"nameservers":[{"id":3,"name":"dave.example.com","server":1,"available":true,"created_at":1727871151,"updated_at":1727871151}]}}'
+  recorded_at: Thu, 11 Sep 2025 11:17:26 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/group-create-nameservers-validation-error.yml
+++ b/spec/fixtures/vcr_cassettes/group-create-nameservers-validation-error.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://dennis.localhost/api/v1/groups
+      body:
+        encoding: UTF-8
+        string: '{"properties":{"name":"Plum Group","external_reference":"plums","nameservers":[{"id":999}]}}'
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+        Authorization:
+          - Bearer test
+        Content-Type:
+          - application/json
+    response:
+      status:
+        code: 404
+        message: Not Found
+      headers:
+        Access-Control-Allow-Methods:
+          - "*"
+        Access-Control-Allow-Origin:
+          - "*"
+        Cache-Control:
+          - no-cache
+        Content-Length:
+          - "137"
+        Content-Type:
+          - application/json
+        Server:
+          - Caddy
+        Server-Timing:
+          - sql.active_record;dur=1.46, instantiation.active_record;dur=0.05
+        X-Api-Schema:
+          - json-error
+        X-Request-Id:
+          - 11949d31-8644-4365-bdbc-65a2814470d5
+        X-Runtime:
+          - "0.007889"
+        Date:
+          - Thu, 11 Sep 2025 10:52:24 GMT
+      body:
+        encoding: UTF-8
+        string:
+          '{"error":{"code":"nameserver_not_found","description":"No nameserver
+          could be found using the given arguments","detail":{"query":"999"}}}'
+    recorded_at: Thu, 11 Sep 2025 10:52:24 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/group-create-nameservers.yml
+++ b/spec/fixtures/vcr_cassettes/group-create-nameservers.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://dennis.localhost/api/v1/groups
+      body:
+        encoding: UTF-8
+        string: '{"properties":{"name":"Pear Group","external_reference":"pears","nameservers":[{"id":1}]}}'
+      headers:
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+        Authorization:
+          - Bearer test
+        Content-Type:
+          - application/json
+    response:
+      status:
+        code: 201
+        message: Created
+      headers:
+        Access-Control-Allow-Methods:
+          - "*"
+        Access-Control-Allow-Origin:
+          - "*"
+        Cache-Control:
+          - max-age=0, private, must-revalidate
+        Content-Length:
+          - "243"
+        Content-Type:
+          - application/json
+        Etag:
+          - W/"dfd9eae2b2e7f8d92272f7d25a0fd01e"
+        Server:
+          - Caddy
+        Server-Timing:
+          - sql.active_record;dur=5.69, instantiation.active_record;dur=0.04
+        X-Request-Id:
+          - 702d9232-5973-4a80-a5e8-e4362a6fe79b
+        X-Runtime:
+          - "0.012972"
+        Date:
+          - Thu, 11 Sep 2025 10:47:54 GMT
+      body:
+        encoding: UTF-8
+        string: '{"group":{"id":6,"name":"Pear Group","external_reference":"pears","created_at":1757587674,"updated_at":1757587674,"nameservers":[{"id":1,"name":"simon.example.com","server":1,"available":true,"created_at":1727871151,"updated_at":1727871151}]}}'
+    recorded_at: Thu, 11 Sep 2025 10:47:54 GMT
+recorded_with: VCR 6.1.0

--- a/spec/specs/group_spec.rb
+++ b/spec/specs/group_spec.rb
@@ -78,33 +78,129 @@ module Dennis
     end
 
     describe '.create' do
-      it 'returns the newly created group' do
-        VCR.use_cassette('group-create') do
-          group = described_class.create(@client, name: 'Apple Group', external_reference: 'apples')
-          expect(group).to be_a Group
-          expect(group).to have_attributes name: 'Apple Group', external_reference: 'apples'
-          expect(group.nameservers).to be_a Array
+      context 'without nameservers' do
+        it 'returns the newly created group' do
+          VCR.use_cassette('group-create') do
+            group = described_class.create(@client, name: 'Apple Group', external_reference: 'apples')
+            expect(group).to be_a Group
+            expect(group).to have_attributes name: 'Apple Group', external_reference: 'apples'
+            expect(group.nameservers).to be_a Array
+          end
+        end
+
+        it 'has nameservers after creation' do
+          VCR.use_cassette('group-create') do
+            group = described_class.create(@client, name: 'Apple Group', external_reference: 'apples')
+            expect(group).to be_a Group
+            expect(group.nameservers).to be_a Array
+            expect(group.nameservers.size).to eq 2
+            expect(group.nameservers).to all be_a Nameserver
+          end
+        end
+
+        it 'raises a validation error if there is an issue' do
+          VCR.use_cassette('group-create-validation-error') do
+            expect do
+              described_class.create(@client, name: '')
+            end.to raise_error ValidationError do |e|
+              expect(e.errors).to match array_including(
+                having_attributes(attribute: 'name', type: 'blank')
+              )
+            end
+          end
         end
       end
 
-      it 'has nameservers after creation' do
-        VCR.use_cassette('group-create') do
-          group = described_class.create(@client, name: 'Apple Group', external_reference: 'apples')
-          expect(group).to be_a Group
-          expect(group.nameservers).to be_a Array
-          expect(group.nameservers.size).to eq 2
-          expect(group.nameservers).to all be_a Nameserver
-        end
-      end
-
-      it 'raises a validation error if there is an issue' do
-        VCR.use_cassette('group-create-validation-error') do
-          expect do
-            described_class.create(@client, name: '')
-          end.to raise_error ValidationError do |e|
-            expect(e.errors).to match array_including(
-              having_attributes(attribute: 'name', type: 'blank')
+      context 'with nameservers passed by id' do
+        it 'returns the newly created group' do
+          VCR.use_cassette('group-create-nameservers') do
+            group = described_class.create(
+              @client,
+              name: 'Pear Group',
+              external_reference: 'pears',
+              nameservers: [{ id: 1 }]
             )
+
+            expect(group).to be_a Group
+            expect(group).to have_attributes name: 'Pear Group', external_reference: 'pears'
+            expect(group.nameservers).to be_a Array
+          end
+        end
+
+        it 'has required nameservers after creation' do
+          VCR.use_cassette('group-create-nameservers') do
+            group = described_class.create(
+              @client,
+              name: 'Pear Group',
+              external_reference: 'pears',
+              nameservers: [{ id: 1 }]
+            )
+
+            expect(group).to be_a Group
+            expect(group.nameservers).to be_a Array
+            expect(group.nameservers.size).to eq 1
+            expect(group.nameservers).to all be_a Nameserver
+            expect(group.nameservers.first.id).to eq 1
+          end
+        end
+
+        it 'raises a validation error if there is an issue' do
+          VCR.use_cassette('group-create-nameservers-validation-error') do
+            expect do
+              described_class.create(
+                @client,
+                name: 'Plum Group',
+                external_reference: 'plums',
+                nameservers: [{ id: 999 }]
+              )
+            end.to raise_error NameserverNotFoundError
+          end
+        end
+      end
+
+      context 'with nameservers passed by name' do
+        it 'returns the newly created group' do
+          VCR.use_cassette('group-create-nameservers-name') do
+            group = described_class.create(
+              @client,
+              name: 'Peach Group',
+              external_reference: 'peaches',
+              nameservers: [{ name: 'dave.example.com' }]
+            )
+
+            expect(group).to be_a Group
+            expect(group).to have_attributes name: 'Peach Group', external_reference: 'peaches'
+            expect(group.nameservers).to be_a Array
+          end
+        end
+
+        it 'has required nameservers after creation' do
+          VCR.use_cassette('group-create-nameservers-name') do
+            group = described_class.create(
+              @client,
+              name: 'Peach Group',
+              external_reference: 'peaches',
+              nameservers: [{ name: 'dave.example.com' }]
+            )
+
+            expect(group).to be_a Group
+            expect(group.nameservers).to be_a Array
+            expect(group.nameservers.size).to eq 1
+            expect(group.nameservers).to all be_a Nameserver
+            expect(group.nameservers.first.name).to eq 'dave.example.com'
+          end
+        end
+
+        it 'raises a validation error if there is an issue' do
+          VCR.use_cassette('group-create-nameservers-name-validation-error') do
+            expect do
+              described_class.create(
+                @client,
+                name: 'Fig Group',
+                external_reference: 'figs',
+                nameservers: [{ name: 'unknown' }]
+              )
+            end.to raise_error NameserverNotFoundError
           end
         end
       end


### PR DESCRIPTION
By default, Dennis allocates available nameservers when creating new groups, unless a specific set of nameservers is provided.

For Onyx, each group created from the app must use a specific set of nameservers. Although the Dennis API already supports this functionality, the client does not currently expose it.
(Reference: [Dennis API code](https://github.com/krystal/dennis/blob/64b40cb06a5475082e40cf33446a04ca9eca5475/app/apis/core_api/argument_sets/group_properties_set.rb#L20-L22))